### PR TITLE
Bmf fix reset scene bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@material-ui/lab": "^3.0.0-alpha.30",
     "babel-loader": "^8.0.6",
     "bootstrap": "^4.3.1",
-    "lodash": "4.17.11",
+    "lodash": ">=4.17.13",
     "mobx": "^5.9.4",
     "mobx-react": "^5.4.3",
     "mobx-utils": "^5.4.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,14 +1,8 @@
 import React, { Component } from 'react';
 import { hot } from 'react-hot-loader/root';
 import MainContent from './components/main-content';
-import UITweaks from './UITweaks';
 
 class App extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {};
-  }
-
   render() {
     return <MainContent />;
   }

--- a/src/components/main-panels/SettingsPanel.jsx
+++ b/src/components/main-panels/SettingsPanel.jsx
@@ -60,6 +60,9 @@ class SettingsPanel extends React.Component {
 
     Object.keys(editState).forEach((changedField) => {
       UIStore.get().setValue('settingsPanel', changedField, editState[changedField]);
+
+      // TODO: abstract this out a bit and autosave changes to localStorage whenever we change anything that should be persisted
+      UIStore.get().saveLocalStorage();
       delete editState[changedField];
     });
   }

--- a/src/models/SceneModel.js
+++ b/src/models/SceneModel.js
@@ -27,11 +27,14 @@ export default class SceneModel extends BaseModel {
     this.displayName = displayName;
     this.clip = clip;
 
-    // handle filename controls
-    if (filename != null) {
-      // hacky way to make this both work in both cases
+    // Handle creating the clipControl objects
+    // This is our hacky way to make this both work in both cases
+    // Clips can have EITHER p1-p8 values OR a filename right now
+    // To make this fully generic, we have to abstract the clip controls in a better way than we are doing right now
+    // If we have another type of clip that uses a 'filename' control, we must update this here or it will break!
+    if (clip.clipId === 'video') {
       this.setFilenameValue(this.clip, filename);
-    // we can only do ONE of these two things, because they both set the clipControls!
+      // we can only do ONE of these two things, because they both set the clipControls!
     } else if (rawClipValues != null) {
       this.setClipValues(this.clip, rawClipValues);
     }

--- a/src/stores/UIStore.js
+++ b/src/stores/UIStore.js
@@ -52,6 +52,23 @@ export default class UIStore {
     return this.instance;
   }
 
+  constructor() {
+    // Load some stuff from local storage
+    this.loadLocalStorage();
+  }
+
+  loadLocalStorage() {
+    const serverAddr = localStorage.getItem('serverAddr');
+
+    if (serverAddr != null) {
+      this.stateTree.settingsPanel.serverAddr = serverAddr;
+    }
+  }
+
+  saveLocalStorage() {
+    localStorage.setItem('serverAddr', this.stateTree.settingsPanel.serverAddr);
+  }
+
   getValue(panelKey, propertyKey) {
     return this.stateTree[panelKey][propertyKey];
   }


### PR DESCRIPTION
Several changes
- Fix bug that broke the 'Reset Scene' button for all non-video clip types
- Upgrade lodash because github told me there's a security vulnerability with the current version
- Save the 'serverAddr' field to localStorage, so changes will persist across browser reloads
  - This is just a QOL improvement so you won't need to update that field with every browser refresh